### PR TITLE
fix typo and path for shortcodes

### DIFF
--- a/docs/advanced/components.mdx
+++ b/docs/advanced/components.mdx
@@ -55,10 +55,10 @@ and then passed to the wrapper. This allows for the wrapper to use
 those props automatically for handling things like adding an author
 bio to the wrapped document.
 
-## `makeShortcodes`
+## `makeShortcode`
 
-There is one other function added to the compiled output: `makeShortcodes`.
-This is added for [shortcode support](/blog/shortcodes). It’s used in order
+There is one other function added to the compiled output: `makeShortcode`.
+This is added for [shortcode support](/docs/blog/shortcodes.mdx). It’s used in order
 to stub any components that aren’t directly imported so that there won’t be
 any `ReferenceError`s. If they’re passed to the `MDXProvider`, the custom
 JSX pragma will pull the component from context and use that in place of the


### PR DESCRIPTION
Change `makeShortcodes` to `makeShortcode` and fix link to shortcodes page